### PR TITLE
Force lsif-java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13
-      - run: sbt scalafmtCheckAll scalafmtSbtCheck "scalafixAll --check"
+      - run: sbt checkAll

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,18 @@ developers := List(
   )
 )
 
+commands +=
+  Command.command("fixAll") { s =>
+    "scalafixAll" :: "scalafmtAll" :: "scalafmtSbt" :: s
+  }
+
+commands +=
+  Command.command("checkAll") { s =>
+    "scalafmtCheckAll" :: "scalafmtSbtCheck" ::
+      "scalafixAll --check" :: "publishLocal" ::
+      s
+  }
+
 // Cross-building settings (see https://github.com/sbt/sbt/issues/3473#issuecomment-325729747)
 def scala212 = "2.12.13"
 def scala210 = "2.10.7"

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
@@ -22,6 +22,8 @@ object SourcegraphPlugin extends AutoPlugin {
       taskKey[File](
         "Task to generate a single LSIF index for all SemanticDB files in this workspace."
       )
+    val sourcegraphLsifJavaVersion: SettingKey[String] =
+      settingKey[String]("The version of the `lsif-java` command-line tool.")
     val sourcegraphSemanticdbDirectories: TaskKey[List[File]] =
       taskKey[List[File]](
         "Task to compile all projects in this build and aggregate all SemanticDB directories."
@@ -69,6 +71,10 @@ object SourcegraphPlugin extends AutoPlugin {
   import autoImport._
 
   override lazy val buildSettings: Seq[Def.Setting[_]] = List(
+    sourcegraphLsifJavaVersion := {
+      scala.util.Properties
+        .propOrElse("lsif-java-version", Versions.semanticdbJavacVersion())
+    },
     sourcegraphLsif := {
       val out = target.in(Sourcegraph).value / "dump.lsif"
       out.getParentFile.mkdirs()
@@ -87,7 +93,7 @@ object SourcegraphPlugin extends AutoPlugin {
         sourcegraphCoursierBinary.value ::
           "launch" ::
           "--contrib" ::
-          "lsif-java" ::
+          s"lsif-java:${sourcegraphLsifJavaVersion.value}" ::
           "--" ::
           "index-semanticdb" ::
           s"--output=$out" ::

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -25,7 +25,7 @@ object Versions {
       props.asScala.toMap
     } else {
       Map(
-        semanticdbJavacKey -> "0.6.2",
+        semanticdbJavacKey -> "0.6.3",
         "2.12.12" -> scalametaVersion,
         "2.13.6" -> scalametaVersion,
         "2.11.12" -> scalametaVersion


### PR DESCRIPTION
Previously, the lsif-java version was inferred by `coursier launch`.
This caused problems because Coursier didn't always pick up the latest
release, even a few days after the release was out.  Now, we explicitly
specify the version to ensure that we use the latest release is picked
up.