### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -7,7 +7,7 @@ import scala.collection.JavaConverters._
 import scala.sys.process._
 
 object Versions {
-  def scalametaVersion = "4.4.25"
+  def scalametaVersion = "4.4.26"
   private def semanticdbJavacKey = "semanticdb-javac"
 
   def semanticdbJavacVersion(): String =


### PR DESCRIPTION
- Fix `sourcegraphEnable` implementation for Scala projects
- Generate javacopts.txt file even in pure-Java projects.
- Recover from partial compile errors
- Bump to the latest default Scalameta version