### PR TITLE
More fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13
-      - run: sbt +test
+      - run: sbt scripted +test
   check:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -75,5 +75,11 @@ buildInfoKeys := List[BuildInfoKey](
 )
 buildInfoPackage := "com.sourcegraph.sbtsourcegraph"
 enablePlugins(BuildInfoPlugin)
+enablePlugins(ScriptedPlugin)
+scriptedBufferLog := false
+scriptedLaunchOpts ++= Seq(
+  "-Xmx2048M",
+  s"-Dplugin.version=${version.value}"
+)
 
 def isCI = "true" == System.getenv("CI")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,8 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-94-1cfdf0bd")
 
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+
 Compile / unmanagedSourceDirectories +=
   (ThisBuild / baseDirectory).value.getParentFile /
     "src" / "main" / "scala"

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
@@ -43,7 +43,7 @@ object SourcegraphEnable {
             javacOptions.in(p) += s"-Xplugin:semanticdb " +
               s"-build-tool:sbt " +
               s"-sourceroot:${baseDirectory.in(ThisBuild).value} " +
-              s"-targetroot:${classDirectory.in(Compile).value.toPath().resolveSibling("semanticdb-classes")}"
+              s"-targetroot:${classDirectory.in(p, Compile).value.toPath().resolveSibling("semanticdb-classes")}"
           ),
           overriddenScalaVersion.map(v => scalaVersion.in(p) := v),
           Option(SemanticdbPlugin.semanticdbEnabled.in(p) := true),

--- a/src/sbt-test/sbt-sourcegraph/basic/a/src/main/java/aj/A.java
+++ b/src/sbt-test/sbt-sourcegraph/basic/a/src/main/java/aj/A.java
@@ -1,0 +1,8 @@
+package aj;
+
+import geny.Generator;
+import org.junit.Assert;
+
+public class A {
+  public geny.Generator x = a.A.generator();
+}

--- a/src/sbt-test/sbt-sourcegraph/basic/a/src/main/scala/a/A.scala
+++ b/src/sbt-test/sbt-sourcegraph/basic/a/src/main/scala/a/A.scala
@@ -1,0 +1,8 @@
+package a
+
+import org.junit.Assert
+
+object A extends App {
+  def generator = geny.Generator(1)
+  Assert.assertEquals(generator, "")
+}

--- a/src/sbt-test/sbt-sourcegraph/basic/b/src/test/java/bj/B.java
+++ b/src/sbt-test/sbt-sourcegraph/basic/b/src/test/java/bj/B.java
@@ -1,0 +1,5 @@
+package bj;
+
+public class B {
+	public geny.Generator generator = a.A.generator();
+}

--- a/src/sbt-test/sbt-sourcegraph/basic/build.sbt
+++ b/src/sbt-test/sbt-sourcegraph/basic/build.sbt
@@ -1,0 +1,44 @@
+import scala.collection.JavaConverters._
+import java.nio.file.Paths
+import java.nio.file.Files
+
+inThisBuild(
+  List(
+    scalaVersion := "2.12.14",
+    organization := "com.example"
+  )
+)
+
+lazy val a = project
+  .settings(
+    libraryDependencies += "com.lihaoyi" %% "geny" % "0.6.10",
+    libraryDependencies += "junit" % "junit" % "4.13.2"
+  )
+
+lazy val b = project
+  .dependsOn(a)
+
+commands += Command.command("checkLsif") { s =>
+  val dumpPath =
+    (ThisBuild / baseDirectory).value / "target" / "sbt-sourcegraph" / "dump.lsif"
+  val dump = Files.readAllLines(dumpPath.toPath).asScala
+  val packageInformation =
+    """.*"name":"(.*)","manager":"jvm-dependencies"}""".r
+  val jvmDependencies = dump
+    .collect { case packageInformation(name) =>
+      name
+    }
+    .distinct
+    .sorted
+  if (
+    jvmDependencies != List(
+      "jdk",
+      "maven/com.lihaoyi/geny_2.12",
+      "maven/junit/junit",
+      "maven/org.scala-lang/scala-library"
+    )
+  ) {
+    sys.error(jvmDependencies.toString)
+  }
+  s
+}

--- a/src/sbt-test/sbt-sourcegraph/basic/project/build.properties
+++ b/src/sbt-test/sbt-sourcegraph/basic/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.2

--- a/src/sbt-test/sbt-sourcegraph/basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-sourcegraph/basic/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % sys.props("plugin.version"))

--- a/src/sbt-test/sbt-sourcegraph/basic/test
+++ b/src/sbt-test/sbt-sourcegraph/basic/test
@@ -1,0 +1,3 @@
+> sourcegraphEnable
+> sourcegraphLsif
+> checkLsif


### PR DESCRIPTION
- Add scripted tests
- De-duplicate targetroots before calling `lsif-java index-semanticdb`
- Add new `sourcegraphTargetRootsFile` task to generate a file with all
  target root directories. The `lsif-java index` command can use this
  so that we run `index-semanticdb` from lsif-java, instead of having
  sbt-sourcegraph run `cs launch --contrib lsif-java`.