### PR TITLE
replaces usages of Lsif* tasks and settings with Scip*

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: coursier/setup-action@v1.1.2
         with:
           jvm: adopt:8
-          apps: lsif-java
-      - run: lsif-java index
+      - run: cs launch --contrib scip-java -- index
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         with:

--- a/readme.md
+++ b/readme.md
@@ -136,9 +136,9 @@ sbt sourcegraphUpload
 
 **Tasks**:
 
-- `sourcegraphLsif`: compiles all projects in the build and generates an LSIF
+- `sourcegraphScip`: compiles all projects in the build and generates an LSIF
   index from the compiled SemanticDB files.
-- `sourcegraphUpload`: uploads the LSIF index from `sourcegraphLsif` to
+- `sourcegraphUpload`: uploads the LSIF index from `sourcegraphScip` to
   Sourcegraph.
 
 **Optional settings**:
@@ -155,10 +155,13 @@ sbt sourcegraphUpload
   flags you may want to configure.
 - `sourcegraphRoot: String`: root directory of this sbt build.
 
-**Removed settings**:
+**Removed settings and tasks**:
 
 - (no longer used) `sourcegraphLsifSemanticdbBinary: String`: path to the
   [`lsif-semanticdb`](https://github.com/sourcegraph/lsif-semanticdb/) binary.
+- `sourcegraphLsif` which has now been replaced with `sourcegraphScip`
+- `sourcegraphLsifVersion` which has now been replaced with
+    `sourcegraphScipVersion`
 
 ## Disable plugin for specific project
 

--- a/src/sbt-test/sbt-sourcegraph/basic/test
+++ b/src/sbt-test/sbt-sourcegraph/basic/test
@@ -1,3 +1,3 @@
 > sourcegraphEnable
-> sourcegraphLsif
+> sourcegraphScip
 > checkLsif


### PR DESCRIPTION
From looking at the recent changes to scip-java when you call index on a
project it expects the `sourcegraphScip` task to be there. This pr makes
the changes to align the task and setting names.

### Test plan

Existing tests still work.