### PR TITLE
chore: bump sbt to 1.6.2 and move to unified slash syntax

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: coursier/setup-action@v1.1.2
         with:
           jvm: adopt:8
-          apps: lsif-java
-      - run: lsif-java index
+      - run: cs launch --contrib scip-java -- index
       - name: Upload LSIF data
         uses: sourcegraph/lsif-upload-action@master
         with:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.6.2

--- a/readme.md
+++ b/readme.md
@@ -136,9 +136,9 @@ sbt sourcegraphUpload
 
 **Tasks**:
 
-- `sourcegraphLsif`: compiles all projects in the build and generates an LSIF
+- `sourcegraphScip`: compiles all projects in the build and generates an LSIF
   index from the compiled SemanticDB files.
-- `sourcegraphUpload`: uploads the LSIF index from `sourcegraphLsif` to
+- `sourcegraphUpload`: uploads the LSIF index from `sourcegraphScip` to
   Sourcegraph.
 
 **Optional settings**:
@@ -155,10 +155,13 @@ sbt sourcegraphUpload
   flags you may want to configure.
 - `sourcegraphRoot: String`: root directory of this sbt build.
 
-**Removed settings**:
+**Removed settings and tasks**:
 
 - (no longer used) `sourcegraphLsifSemanticdbBinary: String`: path to the
   [`lsif-semanticdb`](https://github.com/sourcegraph/lsif-semanticdb/) binary.
+- `sourcegraphLsif` which has now been replaced with `sourcegraphScip`
+- `sourcegraphLsifVersion` which has now been replaced with
+    `sourcegraphScipVersion`
 
 ## Disable plugin for specific project
 

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
@@ -36,18 +36,18 @@ object SourcegraphEnable {
       enableSemanticdbPlugin =
         List(
           Option(
-            allDependencies.in(p) +=
+            (p / allDependencies) +=
               "com.sourcegraph" % "semanticdb-javac" % semanticdbJavacVersion
           ),
           Option(
-            javacOptions.in(p) += s"-Xplugin:semanticdb " +
+            (p / javacOptions) += s"-Xplugin:semanticdb " +
               s"-build-tool:sbt " +
-              s"-sourceroot:${baseDirectory.in(ThisBuild).value} " +
-              s"-targetroot:${classDirectory.in(p, Compile).value.toPath().resolveSibling("semanticdb-classes")}"
+              s"-sourceroot:${(ThisBuild / baseDirectory).value} " +
+              s"-targetroot:${(p / Compile / classDirectory).value.toPath().resolveSibling("semanticdb-classes")}"
           ),
-          overriddenScalaVersion.map(v => scalaVersion.in(p) := v),
-          Option(SemanticdbPlugin.semanticdbEnabled.in(p) := true),
-          Option(SemanticdbPlugin.semanticdbVersion.in(p) := semanticdbVersion)
+          overriddenScalaVersion.map(v => (p / scalaVersion) := v),
+          Option((p / SemanticdbPlugin.semanticdbEnabled) := true),
+          Option((p / SemanticdbPlugin.semanticdbVersion) := semanticdbVersion)
         ).flatten
       settings <-
         inScope(ThisScope.in(p))(
@@ -78,17 +78,16 @@ object SourcegraphEnable {
         extracted
       )
       isSemanticdbEnabled =
-        libraryDependencies
-          .in(p)
+        (p / libraryDependencies)
           .get(extracted.structure.data)
           .exists(_.exists(_.name == "semanticdb-scalac"))
       if !isSemanticdbEnabled
       addSemanticdbCompilerPlugin = List(
         overriddenScalaVersion.map { v =>
-          scalaVersion.in(p) := v
+          (p / scalaVersion) := v
         },
         Option(
-          allDependencies.in(p) += compilerPlugin(
+          (p / allDependencies) += compilerPlugin(
             SourcegraphPlugin.autoImport.sourcegraphSemanticdb(
               semanticdbVersion
             )
@@ -105,8 +104,8 @@ object SourcegraphEnable {
 
   private val semanticdbConfigSettings: Seq[Def.Setting[_]] =
     Seq(
-      scalacOptions.in(compile) := {
-        val old = scalacOptions.in(compile).value
+      (compile / scalacOptions) := {
+        val old = (compile / scalacOptions).value
         val options = List(
           "-Yrangepos",
           "-Xplugin-require:semanticdb"
@@ -121,8 +120,7 @@ object SourcegraphEnable {
       extracted: Extracted
   ): Seq[(ProjectRef, String, Option[String])] = for {
     p <- extracted.structure.allProjectRefs
-    projectScalaVersion <- scalaVersion
-      .in(p)
+    projectScalaVersion <- (p / scalaVersion)
       .get(extracted.structure.data)
       .toList
     overriddenScalaVersion =

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
@@ -99,7 +99,7 @@ object SourcegraphPlugin extends AutoPlugin {
     },
     sourcegraphTargetRootsFile := {
       val roots = sourcegraphTargetRoots.value
-      val out = target.in(Sourcegraph).value / "targetroots.txt"
+      val out = (Sourcegraph / target).value / "targetroots.txt"
       Files.createDirectories(out.toPath().getParent())
       Files.write(
         out.toPath(),
@@ -110,7 +110,7 @@ object SourcegraphPlugin extends AutoPlugin {
       out
     },
     sourcegraphScip := {
-      val out = target.in(Sourcegraph).value / "dump.lsif"
+      val out = (Sourcegraph / target).value / "dump.lsif"
       out.getParentFile.mkdirs()
       runProcess(
         sourcegraphCoursierBinary.value ::
@@ -158,11 +158,11 @@ object SourcegraphPlugin extends AutoPlugin {
     sourcegraphSrcBinary := "src",
     sourcegraphEndpoint := None,
     sourcegraphExtraUploadArguments := Nil,
-    sourcegraphRoot := baseDirectory.in(ThisBuild).value,
-    target.in(Sourcegraph) := baseDirectory.in(ThisBuild).value /
+    sourcegraphRoot := (ThisBuild / baseDirectory).value,
+    (Sourcegraph / target) := (ThisBuild / baseDirectory).value /
       "target" / "sbt-sourcegraph",
     sourcegraphCoursierBinary := createCoursierBinary(
-      target.in(Sourcegraph).value
+      (Sourcegraph / target).value
     )
   )
 
@@ -259,8 +259,8 @@ object SourcegraphPlugin extends AutoPlugin {
 
   val relaxScalacOptionsConfigSettings: Seq[Def.Setting[_]] =
     Seq(
-      scalacOptions.in(compile) := {
-        val options = scalacOptions.in(compile).value
+      (compile / scalacOptions) := {
+        val options = (compile / scalacOptions).value
         options.filterNot { option =>
           scalacOptionsToRelax.exists(_.matcher(option).matches)
         }

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
@@ -1,14 +1,15 @@
 package com.sourcegraph.sbtsourcegraph
 
-import sbt._
 import sbt.Keys._
+import sbt._
+import sbt.internal.sbtsourcegraph.Compat
 import sbt.plugins.JvmPlugin
-import scala.collection.JavaConverters._
+
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
-import sbt.internal.sbtsourcegraph.Compat
+import scala.collection.JavaConverters._
 
 object SourcegraphPlugin extends AutoPlugin {
   override def trigger = allRequirements
@@ -18,7 +19,7 @@ object SourcegraphPlugin extends AutoPlugin {
       taskKey[Unit](
         "Task to upload the LSIF index to Sourcegraph to enable precise code intelligence."
       )
-    val sourcegraphLsif: TaskKey[File] =
+    val sourcegraphScip: TaskKey[File] =
       taskKey[File](
         "Task to generate a single LSIF index for all SemanticDB files in this workspace."
       )
@@ -30,13 +31,12 @@ object SourcegraphPlugin extends AutoPlugin {
       taskKey[File](
         "Task to generate a single LSIF index for all SemanticDB files in this workspace."
       )
-    val sourcegraphLsifJavaVersion: SettingKey[String] =
-      settingKey[String]("The version of the `lsif-java` command-line tool.")
+    val sourcegraphScipJavaVersion: SettingKey[String] =
+      settingKey[String]("The version of the `scip-java` command-line tool.")
     val sourcegraphSemanticdbDirectories: TaskKey[List[File]] =
       taskKey[List[File]](
         "Task to compile all projects in this build and aggregate all SemanticDB directories."
       )
-
     val sourcegraphEndpoint: TaskKey[Option[String]] =
       taskKey[Option[String]](
         "URL of your Sourcegraph instance. By default, uploads to https://sourcegraph.com."
@@ -79,9 +79,8 @@ object SourcegraphPlugin extends AutoPlugin {
   import autoImport._
 
   override lazy val buildSettings: Seq[Def.Setting[_]] = List(
-    sourcegraphLsifJavaVersion := {
-      scala.util.Properties
-        .propOrElse("lsif-java-version", Versions.semanticdbJavacVersion())
+    sourcegraphScipJavaVersion := {
+        scala.util.Properties.propOrElse("scip-java-version", Versions.semanticdbJavacVersion())
     },
     sourcegraphTargetRoots := {
       val directories =
@@ -110,14 +109,16 @@ object SourcegraphPlugin extends AutoPlugin {
       )
       out
     },
-    sourcegraphLsif := {
+    sourcegraphScip := {
       val out = target.in(Sourcegraph).value / "dump.lsif"
       out.getParentFile.mkdirs()
       runProcess(
         sourcegraphCoursierBinary.value ::
           "launch" ::
           "--contrib" ::
-          s"lsif-java:${sourcegraphLsifJavaVersion.value}" ::
+          s"scip-java:${sourcegraphScipJavaVersion.value}" ::
+          "-M" ::
+          "com.sourcegraph.scip_java.ScipJava" ::
           "--" ::
           "index-semanticdb" ::
           s"--output=$out" ::
@@ -134,7 +135,7 @@ object SourcegraphPlugin extends AutoPlugin {
             "in https://github.com/sourcegraph/sbt-sourcegraph/blob/main/README.md"
         )
       }
-      val in = sourcegraphLsif.value
+      val in = sourcegraphScip.value
       val uploadCommand = List[Option[String]](
         Some(sourcegraphSrcBinary.value),
         sourcegraphEndpoint.value.map(url => s"--endpoint=$url"),

--- a/src/sbt-test/sbt-sourcegraph/basic/test
+++ b/src/sbt-test/sbt-sourcegraph/basic/test
@@ -1,3 +1,3 @@
 > sourcegraphEnable
-> sourcegraphLsif
+> sourcegraphScip
 > checkLsif


### PR DESCRIPTION
### Test plan

Not 100% sure what to put here, but this is just a dep update and also a refactoring to get rid of warnings. The test plan should just be ensuring that all existing tests continue to pass as there is no new features or functionality.

Also note that this is built on top of https://github.com/sourcegraph/sbt-sourcegraph/pull/48, so you'll want to merge that first.