### PR TITLE
Revert "chore: bump sbt to 1.6.2 and move to unified slash syntax"

### DIFF
--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphPlugin.scala
@@ -100,7 +100,7 @@ object SourcegraphPlugin extends AutoPlugin {
     },
     sourcegraphTargetRootsFile := {
       val roots = sourcegraphTargetRoots.value
-      val out = (Sourcegraph / target).value / "targetroots.txt"
+      val out = target.in(Sourcegraph).value / "targetroots.txt"
       Files.createDirectories(out.toPath().getParent())
       Files.write(
         out.toPath(),
@@ -111,7 +111,7 @@ object SourcegraphPlugin extends AutoPlugin {
       out
     },
     sourcegraphScip := {
-      val out = (Sourcegraph / target).value / "index.scip"
+      val out = target.in(Sourcegraph).value / "index.scip"
       out.getParentFile.mkdirs()
       runProcess(
         sourcegraphCoursierBinary.value ::
@@ -158,11 +158,11 @@ object SourcegraphPlugin extends AutoPlugin {
     sourcegraphSrcBinary := "src",
     sourcegraphEndpoint := None,
     sourcegraphExtraUploadArguments := Nil,
-    sourcegraphRoot := (ThisBuild / baseDirectory).value,
-    (Sourcegraph / target) := (ThisBuild / baseDirectory).value /
+    sourcegraphRoot := baseDirectory.in(ThisBuild).value,
+    target.in(Sourcegraph) := baseDirectory.in(ThisBuild).value /
       "target" / "sbt-sourcegraph",
     sourcegraphCoursierBinary := createCoursierBinary(
-      (Sourcegraph / target).value
+      target.in(Sourcegraph).value
     )
   )
 
@@ -259,8 +259,8 @@ object SourcegraphPlugin extends AutoPlugin {
 
   val relaxScalacOptionsConfigSettings: Seq[Def.Setting[_]] =
     Seq(
-      (compile / scalacOptions) := {
-        val options = (compile / scalacOptions).value
+      scalacOptions.in(compile) := {
+        val options = scalacOptions.in(compile).value
         options.filterNot { option =>
           scalacOptionsToRelax.exists(_.matcher(option).matches)
         }


### PR DESCRIPTION
This reverts commit 653f9cf7cb8eb1a25e28f7f8c13e376689aba25d except upgrading sbt to 1.6.2, it is required to support sbt 0.13

### Test plan

Let's see CI passes, not sure how it goes with `Upload Sourcegraph Code Intel`