### PR TITLE
fix(build): remove CMSClassUnloadingEnabled

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx4G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 -Dfile.encoding=UTF-8


### PR DESCRIPTION
This will cause the project to blow up on jdk 17. With this change
you can correctly load up the build in Metals

### Test plan

Everything should stay green.
