### PR TITLE
dep: bump scip-java to 0.8.7 and semanticdb to 4.5.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import com.sourcegraph.sbtsourcegraph.Versions
 
 val V = new {
   def scala212 = "2.12.12"
-  def scalameta = "4.4.25"
+  def scalameta = "4.5.13"
 }
 
 scalaVersion := V.scala212

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -7,7 +7,7 @@ import scala.collection.JavaConverters._
 import scala.sys.process._
 
 object Versions {
-  def scalametaVersion = "4.4.26"
+  def scalametaVersion = "4.5.13"
   private def semanticdbJavacKey = "semanticdb-javac"
 
   def semanticdbJavacVersion(): String =
@@ -25,9 +25,9 @@ object Versions {
       props.asScala.toMap
     } else {
       Map(
-        semanticdbJavacKey -> "0.8.0",
-        "2.12.12" -> scalametaVersion,
-        "2.13.6" -> scalametaVersion,
+        semanticdbJavacKey -> "0.8.7",
+        "2.12.16" -> scalametaVersion,
+        "2.13.8" -> scalametaVersion,
         "2.11.12" -> scalametaVersion
       ).withDefaultValue(scalametaVersion)
     }


### PR DESCRIPTION
This also bumps the default scala versions

### Test plan

All tests should remain green.
