### PR TITLE
chore(ci): cleanup CI to use setup-java and bump deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: 8
       - run: sbt scripted +test
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: 8
       - run: sbt checkAll

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -8,7 +8,7 @@ jobs:
   check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: { repository: 'sourcegraph/sourcegraph' }
       - uses: actions/setup-go@v2
         with: { go-version: '1.18' }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
-      - uses: olafurpg/setup-gpg@v3
-      - run: git fetch --unshallow
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+          cache: 'sbt'
       - name: Publish ${{ github.ref }}
         run: sbt ci-release
         env:

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -4,19 +4,25 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
-  lsif:
+  scip:
     runs-on: ubuntu-latest
-    name: "Upload LSIF"
+    name: "Upload SCIP"
     steps:
-      - uses: actions/checkout@v2
-      - uses: coursier/setup-action@v1.1.2
+      - uses: actions/checkout@v3
+      - uses: coursier/setup-action@v1
         with:
-          jvm: adopt:8
-      - run: |
-          cs launch com.sourcegraph:scip-java_2.13:latest.stable -M com.sourcegraph.scip_java.ScipJava -- index
-      - run: yarn global add @sourcegraph/src
-      - run: |
-          src code-intel upload "-commit=${GITHUB_SHA}" "-github-token=${GITHUB_TOKEN}"
+          jvm: 'temurin:8'
+          apps: scip-java
+
+      - name: Generate SCIP File
+        run: scip-java index
+
+      - name: Install src
+        run: yarn global add @sourcegraph/src
+
+      - name: Upload SCIP file
+        run: src code-intel upload -github-token $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This aligns CI a bit better with how it's being done in scip-java. It
also ensures actions/checkout is up to date and that the sourcegraph
upload is the newly recommended way of using the yarn installed `src`.

Supercedes #36
Relates to some CI changes in #51
Supercedes #56

### Test plan

Everything should remain green.
