### PR TITLE
dep: don't directly rely on the Bloop plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,6 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.9-22-2d02726c")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
Not fully sure why this was added, but tools like Metals will
automatically add this if needed. For other editors sbt can also
be a build server, and then this plugin isn't needed.

### Test plan

Tests should remain green.
