### PR TITLE
Fix plugin for Scala 3 projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,9 @@ Compile / resourceGenerators += Def.task {
   if (!out.exists()) {
     val versions = Versions.semanticdbVersionsByScalaVersion()
     val props = new Properties()
-    props.putAll(versions.asJava)
+    versions.foreach { case (k, v) =>
+      props.put(k, v)
+    }
     IO.write(props, "SemanticDB versions grouped by Scala version.", out)
   }
   List(out)
@@ -84,3 +86,4 @@ scriptedLaunchOpts ++= Seq(
 )
 
 def isCI = "true" == System.getenv("CI")
+ThisBuild / version := { if (!isCI) "dev" else version.value }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.9.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,6 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.9-22-2d02726c")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
@@ -140,7 +140,6 @@ object SourcegraphEnable {
       )
         Some("2.11.12")
       else None
-    // For Scala 3 projects,
     semanticdbVersion = Versions
       .semanticdbVersion(overriddenScalaVersion.getOrElse(projectScalaVersion))
   } yield (p, semanticdbVersion, overriddenScalaVersion)

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -15,7 +15,12 @@ object Versions {
       throw new NoSuchElementException(semanticdbJavacKey)
     )
   def semanticdbVersion(scalaVersion: String): Option[String] =
-    cachedSemanticdbVersionsByScalaVersion.get(scalaVersion)
+    // Scala 3 has semanticdb generation built in, so we don't need to
+    // add the semanticdb-scalac plugin
+    if (scalaVersion.startsWith("3."))
+      None
+    else
+      cachedSemanticdbVersionsByScalaVersion.get(scalaVersion)
   lazy val cachedSemanticdbVersionsByScalaVersion: Map[String, String] = {
     val key = "/sbt-sourcegraph/semanticdb.properties"
     val in = this.getClass().getResourceAsStream(key)

--- a/src/sbt-test/sbt-sourcegraph/scala-3/build.sbt
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "3.3.0"

--- a/src/sbt-test/sbt-sourcegraph/scala-3/project/build.properties
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.3

--- a/src/sbt-test/sbt-sourcegraph/scala-3/project/plugins.sbt
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/project/plugins.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin(
+  "com.sourcegraph" % "sbt-sourcegraph" % sys.props("plugin.version")
+)
+
+libraryDependencies += "com.sourcegraph" % "scip-semanticdb" %
+  sys.props("scip-java.version")

--- a/src/sbt-test/sbt-sourcegraph/scala-3/src/main/scala/Test.scala
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/src/main/scala/Test.scala
@@ -1,0 +1,4 @@
+object Hello:
+  def world() = ""
+
+@main def entrypoint = println(Hello.world())

--- a/src/sbt-test/sbt-sourcegraph/scala-3/test
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/test
@@ -1,0 +1,2 @@
+> sourcegraphEnable
+> sourcegraphCompile

--- a/src/sbt-test/sbt-sourcegraph/scala-3/test
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/test
@@ -1,2 +1,4 @@
 > sourcegraphEnable
+> show semanticdbEnabled
+> show Compile/semanticdbEnabled
 > sourcegraphCompile


### PR DESCRIPTION
I've noticed that Scala 3 projects don't work, and identified the issue (semanticdb location calculation).


```
[info] [error] (ThisBuild / sourcegraphTargetRoots) com.sourcegraph.sbtsourcegraph.SourcegraphPlugin$TaskException: Can't upload LSIF index to Sourcegraph because there are no SemanticDB directories. To fix this problem, run the `sourcegraphEnable` command before `sourcegraphCompile` like this: sbt sourcegraphEnable sourcegraphCompile
[info] [error] Total time: 1 s, completed 14 Aug 2023, 13:26:11
[error] x sbt-sourcegraph / scala-3
[error]  Cause of test exception: {line 2}  Command failed: sourcegraphCompile failed
[error] stack trace is suppressed; run last scripted for the full output
[error] (scripted) Failed tests:
[error]         sbt-sourcegraph / scala-3
```

Working on a fix currently

### Test plan

- New scripted plugin test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
