### PR TITLE
Fix java 17 compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,27 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        java: [8, 11, 17]
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: ${{ matrix.java }}
       - run: sbt scripted +test
+
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: 17
       - run: sbt checkAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
           cache: "sbt"
           java-version: ${{ matrix.java }}
       - run: |
-        ls $JAVA_HOME
-        sbt scripted +test
+          ls $JAVA_HOME
+          sbt scripted +test
+        shell: bash
 
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           distribution: "temurin"
           cache: "sbt"
           java-version: ${{ matrix.java }}
-      - run: sbt scripted +test
+      - run: |
+        ls $JAVA_HOME
+        sbt scripted +test
 
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -8,14 +8,13 @@ jobs:
   check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: 'sourcegraph/pr-auditor'
-      - uses: actions/setup-go@v4
-        with: { go-version: '1.20' }
+      - uses: actions/checkout@v2
+        with: { repository: 'sourcegraph/sourcegraph' }
+      - uses: actions/setup-go@v2
+        with: { go-version: '1.18' }
 
-      - run: './check-pr.sh'
+      - run: ./dev/pr-auditor/check-pr.sh
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -10,11 +10,14 @@ jobs:
     name: "Upload LSIF"
     steps:
       - uses: actions/checkout@v2
-      - uses: coursier/setup-action@v1.1.2
+      - uses: actions/setup-java@v3
         with:
-          jvm: adopt:8
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: 17
       - run: |
-          cs launch com.sourcegraph:scip-java_2.13:latest.stable -M com.sourcegraph.scip_java.ScipJava -- index
+          curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs && chmod +x cs
+          ./cs launch com.sourcegraph:scip-java_2.13:latest.stable -M com.sourcegraph.scip_java.ScipJava -- index
       - run: yarn global add @sourcegraph/src
       - run: |
           src code-intel upload "-commit=${GITHUB_SHA}" "-github-token=${GITHUB_TOKEN}"

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
@@ -166,7 +166,7 @@ object SourcegraphEnable {
       .semanticdbVersion(overriddenScalaVersion.getOrElse(projectScalaVersion))
   } yield (p, semanticdbVersion, overriddenScalaVersion)
 
-  def javacModuleOptions =
+  def javacModuleOptions: List[String] =
     List(
       "-J--add-exports",
       "-Jjdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/SourcegraphEnable.scala
@@ -60,9 +60,10 @@ object SourcegraphEnable {
             SemanticdbPlugin.semanticdbVersion.in(p) := ver
           ),
           Option(
-            javaHome.in(p) := javaHome.in(p).value orElse Some(
+            javaHome.in(p) := javaHome.in(p).value orElse Some {
+              println("Oopsie daisy, javaHome is not set")
               new File(System.getProperty("java.home"))
-            )
+            }
           )
         ).flatten
       settings <-

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -81,24 +81,26 @@ object Versions {
               val proc = {
                 val cmd =
                   if (scala.util.Properties.isWin)
-                    Paths.get("bin", "javac.exe")
-                  else Paths.get("bin", "javac")
+                    Paths.get("bin", "java")
+                  else Paths.get("bin", "java")
 
-                val stdout = scala.sys.process
+                scala.sys.process
                   .Process(Seq(cmd.toString(), "-version"), cwd = javaHome)
                   .!!(ProcessLogger(sb.append(_)))
                   .trim
-
-                // Java 8 sends output to stderr...
-                if (stdout.isEmpty()) sb.result().trim else stdout
               }
 
-              proc.split(" ").toList match {
-                case "javac" :: version :: Nil => version
-                case other =>
+              val rgx = "version \"(.*?)\"".r
+
+              rgx.findFirstMatchIn(
+                proc.linesIterator.take(1).mkString("")
+              ) match {
+                case None =>
                   sys.error(
-                    s"Cannot process javac output (in $javaHome): [$proc]"
+                    s"Cannot process [java -version] output (in $javaHome): [$proc]"
                   )
+                case Some(value) =>
+                  value.group(1)
               }
           }
 

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 import java.util.Properties
 import scala.collection.JavaConverters._
 import scala.sys.process._
+import java.io.File
 
 object Versions {
   def scalametaVersion = "4.4.26"
@@ -63,6 +64,64 @@ object Versions {
     Files.deleteIfExists(Paths.get(coursier))
     versions.toList.toMap
       .updated(semanticdbJavacKey, semanticdbJavacVersions.last)
+  }
+
+  private val jvmVersionCache = collection.mutable.Map.empty[Option[File], Int]
+
+  def isJavaAtLeast(n: Int, home: Option[File] = None) = {
+
+    val significant = jvmVersionCache.getOrElseUpdate(
+      home, {
+        val raw =
+          home match {
+            case None =>
+              System.getProperty("java.version")
+            case Some(javaHome) =>
+              val sb = new StringBuilder
+              val proc = {
+                val cmd =
+                  if (scala.util.Properties.isWin)
+                    Paths.get("bin", "javac.exe")
+                  else Paths.get("bin", "javac")
+
+                val stdout = scala.sys.process
+                  .Process(Seq(cmd.toString(), "-version"), cwd = javaHome)
+                  .!!(ProcessLogger(sb.append(_)))
+                  .trim
+
+                // Java 8 sends output to stderr...
+                if (stdout.isEmpty()) sb.result().trim else stdout
+              }
+
+              proc.split(" ").toList match {
+                case "javac" :: version :: Nil => version
+                case other =>
+                  sys.error(
+                    s"Cannot process javac output (in $javaHome): [$proc]"
+                  )
+              }
+          }
+
+        val prop = raw.takeWhile(c => c.isDigit || c == '.')
+
+        val segments = prop.split("\\.").toList
+
+        segments match {
+          // Java 1.6 - 1.8
+          case "1" :: lessThan8 :: _ :: Nil => lessThan8.toInt
+          // Java 17.0.1, ..
+          case modern :: _ :: _ :: Nil => modern.toInt
+          // Java 12
+          case modern :: Nil => modern.toInt
+          case other =>
+            sys.error(
+              s"Cannot process java.home property, unknown format: [$raw]"
+            )
+        }
+      }
+    )
+
+    significant >= n
   }
 
   private def proc(cmd: String*): List[String] = {

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -87,7 +87,8 @@ object Versions {
                 scala.sys.process
                   .Process(Seq(cmd.toString(), "-version"), cwd = javaHome)
                   .!!(ProcessLogger(sb.append(_)))
-                  .trim
+
+                sb.result().trim
               }
 
               val rgx = "version \"(.*?)\"".r

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -68,7 +68,7 @@ object Versions {
 
   private val jvmVersionCache = collection.mutable.Map.empty[Option[File], Int]
 
-  def isJavaAtLeast(n: Int, home: Option[File] = None) = {
+  def isJavaAtLeast(n: Int, home: Option[File] = None): Boolean = {
 
     val significant = jvmVersionCache.getOrElseUpdate(
       home, {

--- a/src/sbt-test/sbt-sourcegraph/basic/build.sbt
+++ b/src/sbt-test/sbt-sourcegraph/basic/build.sbt
@@ -22,9 +22,14 @@ lazy val b = project
     // On Java 8 the java.home property returns JRE path, not JDK path.
     // so we try and work around it hoping that JAVA_HOME is set by executing
     // environment
-    javaHome := Some(
-      new File(sys.env.getOrElse("JAVA_HOME", System.getProperty("java.home")))
-    )
+    javaHome := {
+      println(sys.env.get("JAVA_HOME"))
+      Some(
+        new File(
+          sys.env.getOrElse("JAVA_HOME", System.getProperty("java.home"))
+        )
+      )
+    }
   )
 
 commands += Command.command("checkLsif") { s =>

--- a/src/sbt-test/sbt-sourcegraph/basic/build.sbt
+++ b/src/sbt-test/sbt-sourcegraph/basic/build.sbt
@@ -17,6 +17,15 @@ lazy val a = project
 
 lazy val b = project
   .dependsOn(a)
+  .settings(
+    // Test to ensure the plugin works with explicitly set java home
+    // On Java 8 the java.home property returns JRE path, not JDK path.
+    // so we try and work around it hoping that JAVA_HOME is set by executing
+    // environment
+    javaHome := Some(
+      new File(sys.env.getOrElse("JAVA_HOME", System.getProperty("java.home")))
+    )
+  )
 
 commands += Command.command("checkLsif") { s =>
   val dumpPath =
@@ -32,6 +41,7 @@ commands += Command.command("checkLsif") { s =>
     .filterNot(_ == ".")
     .distinct
     .sorted
+    .toList
   if (
     packageNames != List(
       "jdk",

--- a/src/sbt-test/sbt-sourcegraph/basic/project/build.properties
+++ b/src/sbt-test/sbt-sourcegraph/basic/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.9.3

--- a/src/sbt-test/sbt-sourcegraph/scala-3/test
+++ b/src/sbt-test/sbt-sourcegraph/scala-3/test
@@ -1,4 +1,2 @@
 > sourcegraphEnable
-> show semanticdbEnabled
-> show Compile/semanticdbEnabled
 > sourcegraphCompile


### PR DESCRIPTION
This is currently working on top of #76 

1. pass --add-exports flags to javac when we're on Java 17
   - This has corner cases because we need to manage javaHome, both explicitly set and inherited from the build. Setting java home explicitly is required to prevent Zinc from creating a in-process Java compiler that we cannot configure with -J flags.


### Test plan
- Existing tests were modified to exercise the corner case
- Modify CI to run on Java 8, 11, 17

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
