### PR TITLE
More permissive version matching (e.g. 11.0.20.1)

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -20,6 +20,7 @@ jobs:
       - run: sbt sourcegraphEnable sourcegraphScip
       - run: yarn global add @sourcegraph/src
       - run: |
+          mv target/sbt-sourcegraph/index.scip index.scip
           src code-intel upload "-commit=${GITHUB_SHA}" "-github-token=${GITHUB_TOKEN}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lsif:
     runs-on: ubuntu-latest
-    name: "Upload LSIF"
+    name: "Upload SCIP"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
@@ -15,9 +15,9 @@ jobs:
           distribution: "temurin"
           cache: "sbt"
           java-version: 17
-      - run: |
-          curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs && chmod +x cs
-          ./cs launch com.sourcegraph:scip-java_2.13:latest.stable -M com.sourcegraph.scip_java.ScipJava -- index
+      - run: sbt dumpVersion publishLocal
+      - run: echo "addSbtPlugin(\"com.sourcegraph\" % \"sbt-sourcegraph\" % \"$(cat VERSION)\")" > project/sourcegraph_generated.sbt
+      - run: sbt sourcegraphEnable sourcegraphScip
       - run: yarn global add @sourcegraph/src
       - run: |
           src code-intel upload "-commit=${GITHUB_SHA}" "-github-token=${GITHUB_TOKEN}"

--- a/build.sbt
+++ b/build.sbt
@@ -84,3 +84,15 @@ scriptedLaunchOpts ++= Seq(
   s"-Dscip-java.version=${Versions.semanticdbJavacVersion()}",
   s"-Dplugin.version=${version.value}"
 )
+
+lazy val dumpVersion = taskKey[Unit](
+  "Dump the version of sbt-sourcegraph to a VERSION file"
+)
+dumpVersion := {
+  val versionValue = version.value
+
+  val path = (ThisBuild / baseDirectory).value / "VERSION"
+  IO.write(path, versionValue)
+
+  sLog.value.info(s"Dumping version [$versionValue] to path [$path]")
+}

--- a/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
+++ b/src/main/scala/com/sourcegraph/sbtsourcegraph/Versions.scala
@@ -142,13 +142,13 @@ object Versions {
         segments match {
           // Java 1.6 - 1.8
           case "1" :: lessThan8 :: _ :: Nil => lessThan8.toInt
-          // Java 17.0.1, ..
-          case modern :: _ :: _ :: Nil => modern.toInt
+          // Java 17.0.1, 11.0.20.1, ..
+          case modern :: _ :: _ :: rest => modern.toInt
           // Java 12
           case modern :: Nil => modern.toInt
           case other =>
             sys.error(
-              s"Cannot process java.home property, unknown format: [$raw]"
+              s"Cannot process [java.version] property, unknown format: [$raw]"
             )
         }
       }


### PR DESCRIPTION
Closes #85 

### Test plan

The temurin latest version changed recently from 11.0.20 to 11.0.20.1 (see https://github.com/scalameta/metals/actions/runs/6097314874/job/16544701050#step:4:11), so if all goes well we this PR should stay green.

Additionally, we switch to a bootstrapped SCIP upload (using the plugin's sources), to guarantee it works at least in our environment

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
